### PR TITLE
Use self.client_id for resource param in token request

### DIFF
--- a/oauthenticator/azuread.py
+++ b/oauthenticator/azuread.py
@@ -75,7 +75,7 @@ class AzureAdOAuthenticator(OAuthenticator):
             client_secret=self.client_secret,
             grant_type = 'authorization_code',
             code=code,
-            resource='a67c1e23-de97-4783-99f3-db500c34982c',
+            resource=self.client_id,
             redirect_uri=self.get_callback_url(handler)
         )
 


### PR DESCRIPTION
Looks like you left your own AppID GUID in here by mistake. This should be the self.client_id